### PR TITLE
Handle interrupt and EOT

### DIFF
--- a/include/concoct.h
+++ b/include/concoct.h
@@ -28,6 +28,8 @@
 #ifndef CONCOCT_H
 #define CONCOCT_H
 
+#include <stdbool.h> // bool
+
 #ifdef _WIN32
 static const char ARG_PREFIX = '/';
 #else
@@ -43,6 +45,7 @@ void lex_string(const char* input_string);
 void parse_file(const char* file_name);
 void parse_string(const char* input_string);
 void handle_options(int argc, char *argv[]);
+bool compare_input(const char* input, const char* command);
 void print_license();
 void print_usage();
 void print_version();

--- a/include/concoct.h
+++ b/include/concoct.h
@@ -43,6 +43,7 @@ void lex_string(const char* input_string);
 void parse_file(const char* file_name);
 void parse_string(const char* input_string);
 void handle_options(int argc, char *argv[]);
+void print_license();
 void print_usage();
 void print_version();
 void interactive_mode();

--- a/include/concoct.h
+++ b/include/concoct.h
@@ -49,6 +49,7 @@ bool compare_input(const char* input, const char* command);
 void print_license();
 void print_usage();
 void print_version();
+void handle_sigint(int sig);
 void interactive_mode();
 
 #endif // CONCOCT_H

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -323,6 +323,19 @@ void print_version()
   return;
 }
 
+bool compare_input(const char* input, const char* command)
+{
+  bool is_match = false;
+#ifdef _WIN32
+  if(_stricmp(input, command) == 0)
+    is_match = true;
+#else
+  if(strcasecmp(input, command) == 0)
+    is_match = true;
+#endif
+  return is_match;
+}
+
 // Interactive mode
 void interactive_mode()
 {
@@ -365,13 +378,16 @@ void interactive_mode()
     // Check if string is empty
     if(input[0] == '\0')
       continue;
-#ifdef _WIN32
-    if(_stricmp(input, "quit") == 0)
+
+    // Check for valid commands
+    if(compare_input(input, "license"))
+    {
+      print_license();
+      continue;
+    }
+    if(compare_input(input, "quit"))
       clean_exit(EXIT_SUCCESS);
-#else
-    if(strcasecmp(input, "quit") == 0)
-      clean_exit(EXIT_SUCCESS);
-#endif
+
     lex_string(input);
     parse_string(input);
   }

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -279,7 +279,7 @@ void handle_options(int argc, char *argv[])
 
 void print_license()
 {
-  puts("\nBSD 2-Clause License\n");
+  puts("BSD 2-Clause License\n");
   puts("Copyright (c) 2020-2023 BlakeTheBlock and Lloyd Dilley");
   puts("All rights reserved.\n");
   puts("Redistribution and use in source and binary forms, with or without");
@@ -299,7 +299,7 @@ void print_license()
   puts("SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER");
   puts("CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,");
   puts("OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE");
-  puts("OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n");
+  puts("OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.");
   return;
 }
 
@@ -387,6 +387,11 @@ void interactive_mode()
     }
     if(compare_input(input, "quit"))
       clean_exit(EXIT_SUCCESS);
+    if(compare_input(input, "version"))
+    {
+      print_version();
+      continue;
+    }
 
     lex_string(input);
     parse_string(input);

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -319,6 +319,7 @@ void print_usage()
   puts("Options:");
   printf("%cd: debug mode\n", ARG_PREFIX);
   printf("%ch: print usage\n", ARG_PREFIX);
+  printf("%cl: print license\n", ARG_PREFIX);
   printf("%cv: print version\n", ARG_PREFIX);
   return;
 }

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -129,11 +129,13 @@ void parse_file(const char* file_name)
   ConcoctParser* parser = cct_new_parser(file_lexer);
   ConcoctNodeTree* node_tree = cct_parse_program(parser);
   if(parser->error == NULL)
+  {
     cct_print_node(node_tree->root, 0);
+    compile(node_tree);
+  }
   else
     fprintf(stderr, "Parsing error: [%i] %s, got %s\n", parser->error_line, parser->error, cct_token_type_to_string(parser->current_token.type));
   fclose(input_file);
-  compile(node_tree);
   cct_delete_parser(parser);
   cct_delete_char_stream(char_stream);
   cct_delete_node_tree(node_tree);
@@ -148,10 +150,12 @@ void parse_string(const char* input_string)
   ConcoctParser* parser = cct_new_parser(string_lexer);
   ConcoctNodeTree* node_tree = cct_parse_program(parser);
   if(parser->error == NULL)
+  {
     cct_print_node(node_tree->root, 0);
+    compile(node_tree);
+  }
   else
     fprintf(stderr, "Parsing error: [%i] %s, got %s\n", parser->error_line, parser->error, cct_token_type_to_string(parser->current_token.type));
-  compile(node_tree);
   cct_delete_parser(parser);
   printf("Freed parser\n");
   cct_delete_node_tree(node_tree);

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -252,6 +252,10 @@ void handle_options(int argc, char *argv[])
           print_usage();
           exit(EXIT_SUCCESS);
           break;
+        case 'l':
+          print_license();
+          exit(EXIT_SUCCESS);
+          break;
         case 'v':
           print_version();
           exit(EXIT_SUCCESS);
@@ -270,6 +274,32 @@ void handle_options(int argc, char *argv[])
       exit(EXIT_FAILURE);
     }
   }
+  return;
+}
+
+void print_license()
+{
+  puts("\nBSD 2-Clause License\n");
+  puts("Copyright (c) 2020-2023 BlakeTheBlock and Lloyd Dilley");
+  puts("All rights reserved.\n");
+  puts("Redistribution and use in source and binary forms, with or without");
+  puts("modification, are permitted provided that the following conditions are met:\n");
+  puts("1. Redistributions of source code must retain the above copyright notice, this");
+  puts("list of conditions and the following disclaimer.\n");
+  puts("2. Redistributions in binary form must reproduce the above copyright notice,");
+  puts("this list of conditions and the following disclaimer in the documentation");
+  puts("and/or other materials provided with the distribution.\n");
+
+  puts("THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"");
+  puts("AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE");
+  puts("IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE");
+  puts("DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE");
+  puts("FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL");
+  puts("DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR");
+  puts("SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER");
+  puts("CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,");
+  puts("OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE");
+  puts("OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n");
   return;
 }
 

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -27,9 +27,10 @@
 
 #include <ctype.h>       // isspace()
 #include <errno.h>       // errno
+#include <signal.h>      // signal(), SIGINT
 #include <stdbool.h>     // false, true
 #include <stddef.h>      // size_t
-#include <stdio.h>       // FILE, fclose(), fgets(), fprintf(), printf(), puts(), stdin, stderr
+#include <stdio.h>       // FILE, fclose(), fflush(), fgets(), fprintf(), printf(), puts(), stdin, stderr, stdout
 #include <stdlib.h>      // exit(), EXIT_FAILURE, EXIT_SUCCESS
 #include <string.h>      // memset(), strcasecmp()/stricmp(), strcspn(), strerror(), strlen()
 #include "char_stream.h"
@@ -283,6 +284,7 @@ void handle_options(int argc, char *argv[])
   return;
 }
 
+// Displays license
 void print_license()
 {
   puts("BSD 2-Clause License\n");
@@ -309,6 +311,7 @@ void print_license()
   return;
 }
 
+// Displays usage
 void print_usage()
 {
   print_version();
@@ -320,6 +323,7 @@ void print_usage()
   return;
 }
 
+// Displays version
 void print_version()
 {
   if(strlen(GIT_REV) == 0) // git not detected in path
@@ -329,6 +333,7 @@ void print_version()
   return;
 }
 
+// Compares command input
 bool compare_input(const char* input, const char* command)
 {
   bool is_match = false;
@@ -342,9 +347,22 @@ bool compare_input(const char* input, const char* command)
   return is_match;
 }
 
+// Catches interrupt
+void handle_sigint(int sig)
+{
+  signal(SIGINT, handle_sigint);
+  puts("");
+  if(debug_mode)
+    debug_print("Caught interrupt signal: %d", sig);
+  printf("> ");
+  fflush(stdout);
+  return;
+}
+
 // Interactive mode
 void interactive_mode()
 {
+  signal(SIGINT, handle_sigint);
   char input[1024];
   puts("Warning: Expect things to break.");
   while(true)

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -160,10 +160,10 @@ void parse_string(const char* input_string)
     fprintf(stderr, "Parsing error: [%i] %s, got %s\n", parser->error_line, parser->error, cct_token_type_to_string(parser->current_token.type));
   cct_delete_parser(parser);
   if(debug_mode)
-    debug_print("Freed parser\n");
+    debug_print("Freed parser.");
   cct_delete_node_tree(node_tree);
   if(debug_mode)
-    debug_print("Freed node tree\n");
+    debug_print("Freed node tree.");
   cct_delete_char_stream(char_stream);
   return;
 }
@@ -199,7 +199,8 @@ void lex_file(const char* file_name)
       fprintf(stderr, "%s\n", file_lexer->error);
       break;
     }
-    printf("[%i] %s : %s\n", token.line_number, file_lexer->token_text, cct_token_type_to_string(token.type));
+    if(debug_mode)
+      printf("[%i] %s : %s\n", token.line_number, file_lexer->token_text, cct_token_type_to_string(token.type));
     token = cct_next_token(file_lexer);
   }
   fclose(input_file);
@@ -232,7 +233,8 @@ void lex_string(const char* input_string)
       fprintf(stderr, "%s\n", string_lexer->error);
       break;
     }
-    printf("[%i] %s : %s\n", token.line_number, string_lexer->token_text, cct_token_type_to_string(token.type));
+    if(debug_mode)
+      printf("[%i] %s : %s\n", token.line_number, string_lexer->token_text, cct_token_type_to_string(token.type));
     token = cct_next_token(string_lexer);
   }
   cct_delete_lexer(string_lexer);

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -130,7 +130,8 @@ void parse_file(const char* file_name)
   ConcoctNodeTree* node_tree = cct_parse_program(parser);
   if(parser->error == NULL)
   {
-    cct_print_node(node_tree->root, 0);
+    if(debug_mode)
+      cct_print_node(node_tree->root, 0);
     compile(node_tree);
   }
   else
@@ -151,15 +152,18 @@ void parse_string(const char* input_string)
   ConcoctNodeTree* node_tree = cct_parse_program(parser);
   if(parser->error == NULL)
   {
-    cct_print_node(node_tree->root, 0);
+    if(debug_mode)
+      cct_print_node(node_tree->root, 0);
     compile(node_tree);
   }
   else
     fprintf(stderr, "Parsing error: [%i] %s, got %s\n", parser->error_line, parser->error, cct_token_type_to_string(parser->current_token.type));
   cct_delete_parser(parser);
-  printf("Freed parser\n");
+  if(debug_mode)
+    debug_print("Freed parser\n");
   cct_delete_node_tree(node_tree);
-  printf("Freed node tree\n");
+  if(debug_mode)
+    debug_print("Freed node tree\n");
   cct_delete_char_stream(char_stream);
   return;
 }

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -302,7 +302,19 @@ void interactive_mode()
   {
     memset(input, 0, sizeof(input)); // reset input every iteration
     printf("> ");
-    fgets(input, 1024, stdin);
+    if(fgets(input, 1024, stdin) == NULL)
+    {
+      puts("");
+      if(debug_mode)
+      {
+#ifdef _WIN32
+        debug_print("ctrl+z (EOT) detected.");
+#else
+        debug_print("ctrl+d (EOT) detected.");
+#endif // _WIN32
+      }
+      clean_exit(EXIT_SUCCESS); // ctrl+d (Unix) or ctrl+z (Windows) EOT detected
+    }
 
     // Check if input is just whitespace
     bool blank = false;

--- a/src/parser.c
+++ b/src/parser.c
@@ -99,7 +99,7 @@ ConcoctNodeTree* cct_parse_program(ConcoctParser* parser)
   }
 
   tree->node_count = 0;
-  tree->node_max = 256;
+  tree->node_max = CCT_NODE_COUNT_PER_BLOCK;
   tree->nodes = malloc(tree->node_max * sizeof(ConcoctNode*));
 
   if(tree->nodes == NULL)


### PR DESCRIPTION
## Proposed Changes
- Prevent `compile()` if parser fails (closes #50).
- Handle EOT (closes #52).
- Handle SIGINT (closes #53).
- Add `compare_input()` to handle REPL commands.
- Add `license` and `version` commands to REPL.
- Update `print_usage()` to include license ('l') argument.
- Set `tree->node_max` to `CCT_NODE_COUNT_PER_BLOCK`.
- Hide certain output unless debug mode is enabled.