### PR TITLE
Use fixed-width integers for hash map

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -49,8 +49,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/include/hash_map.h
+++ b/include/hash_map.h
@@ -28,40 +28,41 @@
 #ifndef CCT_HASH_MAP_H
 #define CCT_HASH_MAP_H
 
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
+#include <stdbool.h> // false, true
+#include <stdint.h>  // uint32_t
 
-#define CCT_HASH_OFFSET 2166136261
-#define CCT_HASH_PRIME 16777619
+#define CCT_HASH_OFFSET ((uint32_t)2166136261)
+#define CCT_HASH_PRIME ((uint32_t)16777619)
 
 typedef struct ConcoctHashMapNode ConcoctHashMapNode;
 
-struct ConcoctHashMapNode {
-  unsigned int hash;
+struct ConcoctHashMapNode
+{
+  uint32_t hash;
   const char* key;
   void* value;
   ConcoctHashMapNode* next;
 };
 
-typedef struct concoct_hash_map {
+typedef struct concoct_hash_map
+{
   ConcoctHashMapNode** buckets;
-  int bucket_count;
+  uint32_t bucket_count;
 } ConcoctHashMap;
 
-ConcoctHashMapNode* cct_new_hash_map_node(const char* key, void* value, unsigned int hash);
+ConcoctHashMapNode* cct_new_hash_map_node(const char* key, void* value, uint32_t hash);
 void cct_delete_hash_map_node(ConcoctHashMapNode* map);
 
-ConcoctHashMap* cct_new_hash_map(int bucket_count);
+ConcoctHashMap* cct_new_hash_map(uint32_t bucket_count);
 void cct_delete_hash_map(ConcoctHashMap* map);
 
-int cct_hash_map_has_key(ConcoctHashMap* map, const char* key);
+bool cct_hash_map_has_key(const ConcoctHashMap* map, const char* key);
 void cct_hash_map_set(ConcoctHashMap* map, const char* key, void* value);
-void* cct_hash_map_get(ConcoctHashMap* map, const char* key);
+void* cct_hash_map_get(const ConcoctHashMap* map, const char* key);
 void cct_hash_map_delete_entry(ConcoctHashMap* map, const char* key);
 
-ConcoctHashMapNode* get_first_node_in_bucket(ConcoctHashMap* map, int bucket);
+ConcoctHashMapNode* get_first_node_in_bucket(const ConcoctHashMap* map, uint32_t bucket);
 
-unsigned int cct_get_hash_code(const char* str);
+uint32_t cct_get_hash_code(const char* str);
 
-#endif
+#endif // CCT_HASH_MAP_H

--- a/src/tests/hash_map_test.c
+++ b/src/tests/hash_map_test.c
@@ -25,10 +25,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdio.h>    // printf()
 #include "hash_map.h"
 
-#define KEYWORD_COUNT 23
-#define HASH_MAP_BUCKET_COUNT 24
+#define KEYWORD_COUNT ((uint8_t)23)
+#define HASH_MAP_BUCKET_COUNT ((uint16_t)24)
 
 const char* cct_keywords[KEYWORD_COUNT] = {
   "break",
@@ -62,11 +63,11 @@ int main()
   // Print out the results of hashing
   printf("\nHASH MAP TEST\n\n");
   printf("%-9s : %-10s : %s\n\n", "KEY", "HASH_CODE", "BUCKET_INDEX");
-  for(int i = 0; i < KEYWORD_COUNT; i++)
+  for(size_t i = 0; i < KEYWORD_COUNT; i++)
   {
     const char* key = cct_keywords[i];
-    unsigned int hash = cct_get_hash_code(key);
-    int bucket = hash % HASH_MAP_BUCKET_COUNT;
+    uint32_t hash = cct_get_hash_code(key);
+    uint32_t bucket = hash % HASH_MAP_BUCKET_COUNT;
     printf("%-9s : %10u : %d\n", key, hash, bucket);
   }
   printf("\n");
@@ -79,28 +80,16 @@ int main()
   cct_hash_map_set(map, "five", (void*)5);
 
   if(!cct_hash_map_has_key(map, "var"))
-  {
     printf("TEST 1 FAILED: Error while setting and testing a hash map key.\n");
-  }
   else if(!cct_hash_map_has_key(map, "thisIsACrazyLongString"))
-  {
     printf("TEST 2 FAILED: Error while setting and testing a hash map key.\n");
-  }
   else if(cct_hash_map_has_key(map, "thisKeyDoesNotExist"))
-  {
     printf("TEST 3 FAILED: Error while testing for key that does not exist.\n");
-  }
   else if(cct_hash_map_has_key(map, "deleteMe"))
-  {
     printf("TEST 4 FAILED: Error while testing for key that was deleted.\n");
-  }
   else if(cct_hash_map_get(map, "five") != (void*)5)
-  {
     printf("TEST 5 FAILED: Error while retrieving value\n");
-  }
   else
-  {
     printf("ALL TESTS PASSED\n");
-  }
   cct_delete_hash_map(map);
 }

--- a/src/tests/unit_tests.c
+++ b/src/tests/unit_tests.c
@@ -53,6 +53,7 @@ void test_stringify()
   if(str && strlen(str) > 5)
   {
     strncpy(dec, str, 5);
+    dec[5] = '\0';
     assert(strcmp(dec, "57.05") == 0);
   }
   free(str);


### PR DESCRIPTION
## Proposed Change(s)
- Use fixed-width integers for hash map.
- Use `const` for hash map function parameters where applicable.
- Append null terminator to decimal `stringify()` unit test.
- Remove Codecov.
