### PR TITLE
Stack decouple and compiler unary minus support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin")
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(HASH_MAP_TEST_SOURCES src/debug.c src/hash_map.c src/seconds.c src/tests/hash_map_test.c)
-set(INTERPRET_TEST_SOURCES src/debug.c src/hash_map.c src/memory.c src/seconds.c src/types.c
-  src/vm/instructions.c src/vm/opcodes.c src/vm/stack.c src/vm/vm.c src/tests/interpret_test.c)
+set(INTERPRET_TEST_SOURCES src/debug.c src/hash_map.c src/memory.c src/seconds.c src/stack.c
+  src/types.c src/vm/instructions.c src/vm/opcodes.c src/vm/vm.c src/tests/interpret_test.c)
 set(OBJECT_TEST_SOURCES src/debug.c src/memory.c src/seconds.c src/types.c src/tests/object_test.c)
-set(STACK_TEST_SOURCES src/debug.c src/hash_map.c src/memory.c src/seconds.c src/types.c
-  src/vm/instructions.c src/vm/stack.c src/tests/stack_test.c)
+set(STACK_TEST_SOURCES src/debug.c src/hash_map.c src/memory.c src/seconds.c src/stack.c
+  src/types.c src/vm/instructions.c src/tests/stack_test.c)
 set(UNIT_TESTS_SOURCES src/debug.c src/memory.c src/seconds.c src/types.c src/tests/unit_tests.c)
 
 if(MSVC)

--- a/include/memory.h
+++ b/include/memory.h
@@ -29,7 +29,7 @@
 #define MEMORY_H
 
 #include "types.h"
-#include "vm/stack.h"
+#include "stack.h"
 
 // Initial free store capacity
 static const size_t INITIAL_STORE_CAPACITY = 128;

--- a/include/stack.h
+++ b/include/stack.h
@@ -25,59 +25,31 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>    // fprintf(), stderr
-#include <stdlib.h>   // EXIT_FAILURE
-#include "debug.h"
-#include "vm/stack.h"
+#ifndef STACK_H
+#define STACK_H
 
-void init_stack(Stack* stack)
+#include <stddef.h> // NULL
+#include "types.h"
+
+#define MAX_STACK_CAPACITY ((size_t)128)
+
+typedef struct stack
 {
-  stack->count = 0;
-  stack->top = -1;
-  if(debug_mode)
-    debug_print("Stack initialized with %zu slots.", MAX_STACK_CAPACITY);
-  return;
-}
+  int16_t top;
+  size_t count;
+  void* objects[MAX_STACK_CAPACITY];
+} Stack;
+
+// Initializes stack
+void init_stack(Stack* stack);
 
 // Returns object at top of stack without removal
-Object* peek(const Stack* stack)
-{
-  if(stack->top == -1)
-  {
-    if(debug_mode)
-      debug_print("peek() called on empty stack!");
-    return NULL;
-  }
-  if(debug_mode)
-    debug_print("peek() called on stack for object of type %s. Stack currently contains %zu objects.", get_data_type(stack->objects[stack->top]), stack->count);
-  return stack->objects[stack->top];
-}
+void* peek(const Stack* stack);
 
 // Returns and removes object at top of stack
-Object* pop(Stack* stack)
-{
-  if(stack->top == -1)
-  {
-    fprintf(stderr, "Stack underflow occurred!\n");
-    return NULL;
-  }
-  stack->count--;
-  if(debug_mode)
-    debug_print("pop() called on stack for object of type %s. Stack now contains %zu objects.", get_data_type(stack->objects[stack->top]), stack->count);
-  return stack->objects[stack->top--];
-}
+void* pop(Stack* stack);
 
 // Pushes new object on top of stack
-void push(Stack* stack, Object* object)
-{
-  if(stack->top >= ((int)MAX_STACK_CAPACITY - 1))
-  {
-    fprintf(stderr, "Stack overflow occurred!\n");
-    return;
-  }
-  stack->count++;
-  stack->objects[++stack->top] = object;
-  if(debug_mode)
-    debug_print("push() called on stack for object of type %s. Stack now contains %zu objects.", get_data_type(stack->objects[stack->top]), stack->count);
-  return;
-}
+void push(Stack* stack, void* object);
+
+#endif // STACK_H

--- a/include/vm/instructions.h
+++ b/include/vm/instructions.h
@@ -29,7 +29,7 @@
 #define INSTRUCTIONS_H
 
 #include "hash_map.h"
-#include "vm/stack.h"
+#include "stack.h"
 #include "vm/vm.h"
 
 #define OP_NOOP (void)0

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -28,9 +28,9 @@
 #ifndef VM_H
 #define VM_H
 
+#include "stack.h"
 #include "types.h"      // BigNum, Byte
 #include "vm/opcodes.h" // Opcode
-#include "vm/stack.h"   // Stack
 
 #define REGISTER_AMOUNT ((uint8_t)17)
 static const uint8_t REGISTER_EMPTY = 127;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -124,7 +124,10 @@ void compile(ConcoctNodeTree* tree, ConcoctHashMap* map)
         ic++;
         break;
       case CCT_TOKEN_ADD_ASSIGN:
-        // OP_ADD + OP_ASN
+        vm.instructions[ic] = OP_ADD;
+        ic++;
+        vm.instructions[ic] = OP_ASN;
+        ic++;
         break;
       case CCT_TOKEN_AND:
         vm.instructions[ic] = OP_AND;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -276,6 +276,10 @@ void compile(ConcoctNodeTree* tree, ConcoctHashMap* map)
         vm.instructions[ic] = OP_TRU;
         ic++;
         break;
+      case CCT_TOKEN_UNARY_MINUS:
+        vm.instructions[ic] = OP_NEG;
+        ic++;
+        break;
       default:
         fprintf(stderr, "Unable to handle token: %s\n", cct_token_type_to_string(current->token.type));
         break;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -208,7 +208,7 @@ ConcoctToken cct_next_token(ConcoctLexer* lexer)
     if(cct_hash_map_has_key(lexer->keyword_map, lexer->token_text))
     {
       void* void_pointer = cct_hash_map_get(lexer->keyword_map, lexer->token_text);
-      int* pointer_to_type = (int*) (&void_pointer);
+      const int* pointer_to_type = (int *)(&void_pointer);
       type = *pointer_to_type;
     }
     else

--- a/src/parser.c
+++ b/src/parser.c
@@ -219,7 +219,9 @@ ConcoctNode* cct_parse_unary_expr(ConcoctParser* parser)
     case CCT_TOKEN_SUB:
       // Change the token type so the compiler knows which operation it is
       parser->current_token.type = CCT_TOKEN_UNARY_MINUS;
+      goto TOK_ADD_LBL; // portable way to handle intentional fallthrough and silence -Wimplicit-fallthrough
     case CCT_TOKEN_ADD:
+      TOK_ADD_LBL:
     case CCT_TOKEN_NOT:
     case CCT_TOKEN_INC:
     case CCT_TOKEN_DEC:

--- a/src/stack.c
+++ b/src/stack.c
@@ -25,31 +25,59 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef STACK_H
-#define STACK_H
+#include <stdio.h>  // fprintf(), stderr
+#include <stdlib.h> // EXIT_FAILURE
+#include "debug.h"
+#include "stack.h"
 
-#include <stddef.h> // NULL
-#include "types.h"
-
-#define MAX_STACK_CAPACITY ((size_t)64)
-
-typedef struct vm_stack
+void init_stack(Stack* stack)
 {
-  int top;
-  size_t count;
-  Object* objects[MAX_STACK_CAPACITY];
-} Stack;
-
-// Initializes stack
-void init_stack(Stack* stack);
+  stack->count = 0;
+  stack->top = -1;
+  if(debug_mode)
+    debug_print("Stack initialized with %zu slots.", MAX_STACK_CAPACITY);
+  return;
+}
 
 // Returns object at top of stack without removal
-Object* peek(const Stack* stack);
+void* peek(const Stack* stack)
+{
+  if(stack->top == -1)
+  {
+    if(debug_mode)
+      debug_print("peek() called on empty stack!");
+    return NULL;
+  }
+  if(debug_mode)
+    debug_print("peek() called on stack for object of type %s. Stack currently contains %zu objects.", get_data_type(stack->objects[stack->top]), stack->count);
+  return stack->objects[stack->top];
+}
 
 // Returns and removes object at top of stack
-Object* pop(Stack* stack);
+void* pop(Stack* stack)
+{
+  if(stack->top == -1)
+  {
+    fprintf(stderr, "Stack underflow occurred!\n");
+    return NULL;
+  }
+  stack->count--;
+  if(debug_mode)
+    debug_print("pop() called on stack for object of type %s. Stack now contains %zu objects.", get_data_type(stack->objects[stack->top]), stack->count);
+  return stack->objects[stack->top--];
+}
 
 // Pushes new object on top of stack
-void push(Stack* stack, Object* object);
-
-#endif // STACK_H
+void push(Stack* stack, void* object)
+{
+  if(stack->top >= ((int)MAX_STACK_CAPACITY - 1))
+  {
+    fprintf(stderr, "Stack overflow occurred!\n");
+    return;
+  }
+  stack->count++;
+  stack->objects[++stack->top] = object;
+  if(debug_mode)
+    debug_print("push() called on stack for object of type %s. Stack now contains %zu objects.", get_data_type(stack->objects[stack->top]), stack->count);
+  return;
+}

--- a/src/tests/stack_test.c
+++ b/src/tests/stack_test.c
@@ -28,9 +28,9 @@
 #include <stdio.h>
 #include "debug.h"
 #include "memory.h"
+#include "stack.h"
 #include "types.h"
 #include "vm/instructions.h"
-#include "vm/stack.h"
 
 int main()
 {

--- a/src/vm/instructions.c
+++ b/src/vm/instructions.c
@@ -207,7 +207,7 @@ RunCode op_asn(Stack* stack, ConcoctHashMap* map)
     fprintf(stderr, "Value is NULL during ASN operation.\n");
     return RUN_ERROR;
   }
-  cct_hash_map_set(map, key->value.strobj.strval, (Object *)val);
+  cct_hash_map_set(map, key->value.strobj.strval, val);
   if(debug_mode)
     print_object_value((Object *)cct_hash_map_get(map, key->value.strobj.strval));
   key->is_flagged = true; // throw away the key since we have it in the map


### PR DESCRIPTION
## Proposed Change(s)
- Remove unnecessary `Object *` cast in `op_asn()`.
- Fix intentional switch fallthrough warning in a portable manner using `goto`.
- Decouple stack from VM so the data structure can be used elsewhere.
- Add compiler support for unary minus/negative sign.