### PR TITLE
Docker/Podman support, interpret() prototype correction, and musl printf flush fix

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,15 @@
+# Concoct - An imperative, dynamically-typed, interpreted, general-purpose programming language
+# Copyright (c) 2020-2023 BlakeTheBlock and Lloyd Dilley
+# http://concoct.ist/
+
+FROM alpine:latest AS construct
+RUN apk update && apk add clang cmake git make musl-dev && apk cache clean
+RUN cd /root && git clone https://github.com/concoctist/concoct.git
+RUN cd /root/concoct && mkdir bld && cd bld && cmake .. && make
+
+FROM alpine:latest
+RUN adduser -h /home/concoct -g "Concoct Account" -S concoct
+USER concoct
+WORKDIR /home/concoct
+COPY --from=construct --chown=concoct /root/concoct/bld/bin/concoct .
+CMD ["/home/concoct/concoct"]

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -28,9 +28,10 @@
 #ifndef COMPILER_H
 #define COMPILER_H
 
-#include <stdbool.h>  // bool
+#include <stdbool.h>    // bool
 #include "hash_map.h"
 #include "parser.h"
+#include "vm/opcodes.h"
 
 #define MAX_QUEUE_CAPACITY ((size_t)256)
 
@@ -65,6 +66,9 @@ void dequeue(Queue* queue, ConcoctNode** node);
 
 // Inserts new node into queue
 void enqueue(Queue* queue, ConcoctNode* node);
+
+// Swap last 2 stack objects to fix order if first instruction is a binary operation
+void swap_last_operands(Opcode oc);
 
 // Translates lexer/parser tokens to VM instructions
 void compile(ConcoctNodeTree* tree, ConcoctHashMap* map);

--- a/include/vm/opcodes.h
+++ b/include/vm/opcodes.h
@@ -28,6 +28,8 @@
 #ifndef OPCODES_H
 #define OPCODES_H
 
+#include <stdbool.h> // bool
+
 // Supported instruction set
 typedef enum opcode
 {
@@ -66,7 +68,7 @@ typedef enum opcode
   OP_MOD, // modulo (%)
   OP_MOV, // move (from register to register)
   OP_MUL, // multiply (*)
-  OP_NEG, // negative
+  OP_NEG, // negative (unary -)
   OP_NEQ, // not equal to (!=)
   OP_NOP, // no op
   OP_NOT, // logical not/negation (!)
@@ -92,5 +94,11 @@ typedef enum opcode
 
 // Returns opcode constant based on numeric ID
 const char* get_mnemonic(Opcode oc);
+
+// Returns true if opcode is a unary operation
+bool is_unary_operation(Opcode oc);
+
+// Returns true if opcode is a binary operation
+bool is_binary_operation(Opcode oc);
 
 #endif // OPCODES_H

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -28,6 +28,7 @@
 #ifndef VM_H
 #define VM_H
 
+#include "hash_map.h"
 #include "stack.h"
 #include "types.h"      // BigNum, Byte
 #include "vm/opcodes.h" // Opcode
@@ -91,6 +92,6 @@ void init_vm();
 void stop_vm();
 
 // Interprets code
-RunCode interpret();
+RunCode interpret(ConcoctHashMap* map);
 
 #endif // VM_H

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -98,6 +98,22 @@ void enqueue(Queue* queue, ConcoctNode* node)
   return;
 }
 
+// Swap last 2 stack objects to fix order if first instruction is a binary operation
+void swap_last_operands(Opcode oc)
+{
+  Object* object1 = NULL;
+  Object* object2 = NULL;
+  if(!is_binary_operation(oc))
+    return;
+  if(debug_mode)
+    debug_print("Swapping top 2 objects of stack...");
+  object1 = pop(vm.sp);
+  object2 = pop(vm.sp);
+  push(vm.sp, object1);
+  push(vm.sp, object2);
+  return;
+}
+
 // Translates lexer/parser tokens to VM instructions
 void compile(ConcoctNodeTree* tree, ConcoctHashMap* map)
 {
@@ -288,9 +304,13 @@ void compile(ConcoctNodeTree* tree, ConcoctHashMap* map)
       enqueue(pqueue, current->children[i]);
   }
 
-  reverse_instructions(ic);
-  vm.instructions[ic] = OP_END; // append end instruction
-  interpret(map);
+  if(ic > 0)
+  {
+    reverse_instructions(ic);
+    swap_last_operands(vm.instructions[0]);
+    vm.instructions[ic] = OP_END; // append end instruction
+    interpret(map);
+  }
 
   return;
 }

--- a/src/concoct.c
+++ b/src/concoct.c
@@ -222,7 +222,7 @@ void lex_string(const char* input_string)
   //const char* input = "func test() { return a + b }";
   ConcoctCharStream* char_stream = cct_new_string_char_stream(input_string);
   ConcoctLexer* string_lexer = cct_new_lexer(char_stream);
-  
+
   if(string_lexer == NULL)
   {
     fprintf(stderr, "String lexer is NULL!\n");
@@ -376,6 +376,7 @@ void interactive_mode()
   {
     memset(input, 0, sizeof(input)); // reset input every iteration
     printf("> ");
+    fflush(stdout);
     if(fgets(input, 1024, stdin) == NULL)
     {
       puts("");

--- a/src/tests/interpret_test.c
+++ b/src/tests/interpret_test.c
@@ -26,6 +26,7 @@
  */
 
 #include "debug.h"
+#include "hash_map.h"
 #include "memory.h"
 #include "vm/vm.h"
 
@@ -34,6 +35,7 @@ int main()
   Object* object = NULL;
   void* vptr = NULL;
   BigNum numval = -8675309;
+  ConcoctHashMap* map = cct_new_hash_map(INITIAL_BUCKET_AMOUNT);
   debug_mode = true;
   init_vm();
 
@@ -81,7 +83,8 @@ int main()
   vm.instructions[17] = OP_CLS;
   vm.instructions[18] = OP_END;
 
-  interpret();
+  interpret(map);
+  cct_delete_hash_map(map);
   stop_vm();
 
   return 0;

--- a/src/vm/instructions.c
+++ b/src/vm/instructions.c
@@ -195,8 +195,8 @@ RunCode op_psh(Stack* stack, char* value)
 // Assign (=)
 RunCode op_asn(Stack* stack, ConcoctHashMap* map)
 {
-  Object* val = pop(stack); // value
   Object* key = pop(stack); // identifier used as a key
+  Object* val = pop(stack); // value
   if(key == NULL || key->datatype != CCT_TYPE_STRING)
   {
     fprintf(stderr, "Identifier is not a string that can be used as a key during ASN operation.\n");
@@ -231,8 +231,8 @@ RunCode op_tru(Stack* stack)
 // Logical and (&&)
 RunCode op_and(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
   Bool result = false;
   void* vptr = NULL;
 
@@ -291,8 +291,8 @@ RunCode op_not(Stack* stack)
 // Logical or (||)
 RunCode op_or(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
   Bool result = false;
   void* vptr = NULL;
 
@@ -324,8 +324,8 @@ RunCode op_or(Stack* stack)
 // Equal to (==)
 RunCode op_eql(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -503,8 +503,8 @@ RunCode op_eql(Stack* stack)
 // Not equal to (!=)
 RunCode op_neq(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -682,8 +682,8 @@ RunCode op_neq(Stack* stack)
 // String length equal to ($=)
 RunCode op_sle(Stack* stack)
 {
-  const Object* operand2 = pop(stack);
   const Object* operand1 = pop(stack);
+  const Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -715,8 +715,8 @@ RunCode op_sle(Stack* stack)
 // String length not equal to ($!)
 RunCode op_sln(Stack* stack)
 {
-  const Object* operand2 = pop(stack);
   const Object* operand1 = pop(stack);
+  const Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -748,8 +748,8 @@ RunCode op_sln(Stack* stack)
 // Greater than (>)
 RunCode op_gt(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -915,8 +915,8 @@ RunCode op_gt(Stack* stack)
 // Greater than or equal to (>=)
 RunCode op_gte(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -1082,8 +1082,8 @@ RunCode op_gte(Stack* stack)
 // Less than (<)
 RunCode op_lt(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -1249,8 +1249,8 @@ RunCode op_lt(Stack* stack)
 // Less than or equal to (<=)
 RunCode op_lte(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
 
   if(operand1 == NULL)
   {
@@ -1610,8 +1610,8 @@ RunCode op_inc(Stack* stack)
 // Addition (+)
 RunCode op_add(Stack* stack)
 {
-  Object* operand2 = pop(stack); // addend
   Object* operand1 = pop(stack); // augend
+  Object* operand2 = pop(stack); // addend
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -1773,8 +1773,8 @@ RunCode op_add(Stack* stack)
 // Subtraction (-)
 RunCode op_sub(Stack* stack)
 {
-  Object* operand2 = pop(stack); // subtrahend
   Object* operand1 = pop(stack); // minuend
+  Object* operand2 = pop(stack); // subtrahend
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -1920,8 +1920,8 @@ RunCode op_sub(Stack* stack)
 // Division (/)
 RunCode op_div(Stack* stack)
 {
-  Object* operand2 = pop(stack); // divisor
   Object* operand1 = pop(stack); // dividend
+  Object* operand2 = pop(stack); // divisor
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -2095,8 +2095,8 @@ RunCode op_div(Stack* stack)
 // Multiplication (*)
 RunCode op_mul(Stack* stack)
 {
-  Object* operand2 = pop(stack); // multiplicand
   Object* operand1 = pop(stack); // multiplier
+  Object* operand2 = pop(stack); // multiplicand
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -2279,8 +2279,8 @@ RunCode op_mul(Stack* stack)
 // Note: Modulo operates on integers. Decimal numbers are truncated.
 RunCode op_mod(Stack* stack)
 {
-  Object* operand2 = pop(stack); // divisor
   Object* operand1 = pop(stack); // dividend
+  Object* operand2 = pop(stack); // divisor
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -2426,8 +2426,8 @@ RunCode op_mod(Stack* stack)
 // Exponentiation (**)
 RunCode op_pow(Stack* stack)
 {
-  Object* operand2 = pop(stack); // exponent/power to raise by
   Object* operand1 = pop(stack); // base
+  Object* operand2 = pop(stack); // exponent/power to raise by
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -2573,8 +2573,8 @@ RunCode op_pow(Stack* stack)
 // Bitwise and (&)
 RunCode op_bnd(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -2720,8 +2720,8 @@ RunCode op_bnd(Stack* stack)
 // Bitwise or (|)
 RunCode op_bor(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -2867,8 +2867,8 @@ RunCode op_bor(Stack* stack)
 // Bitwise xor (^)
 RunCode op_xor(Stack* stack)
 {
-  Object* operand2 = pop(stack);
   Object* operand1 = pop(stack);
+  Object* operand2 = pop(stack);
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -3067,8 +3067,8 @@ RunCode op_bnt(Stack* stack)
 // Bit shift left (<<)
 RunCode op_shl(Stack* stack)
 {
-  Object* operand2 = pop(stack); // positions to shift
   Object* operand1 = pop(stack); // number to shift
+  Object* operand2 = pop(stack); // positions to shift
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;
@@ -3126,8 +3126,8 @@ RunCode op_shl(Stack* stack)
 // Bit shift right (>>)
 RunCode op_shr(Stack* stack)
 {
-  Object* operand2 = pop(stack); // positions to shift
   Object* operand1 = pop(stack); // number to shift
+  Object* operand2 = pop(stack); // positions to shift
   Byte byteval = 0;
   Number numval = 0;
   BigNum bignumval = 0;

--- a/src/vm/opcodes.c
+++ b/src/vm/opcodes.c
@@ -67,7 +67,7 @@ const char* get_mnemonic(Opcode oc)
     case OP_MOD: return "OP_MOD";    // modulo (%)
     case OP_MOV: return "OP_MOV";    // move (from register to register)
     case OP_MUL: return "OP_MUL";    // multiply (*)
-    case OP_NEG: return "OP_NEG";    // negative
+    case OP_NEG: return "OP_NEG";    // negative (unary -)
     case OP_NEQ: return "OP_NEQ";    // not equal to (!=)
     case OP_NOP: return "OP_NOP";    // no op
     case OP_NOT: return "OP_NOT";    // logical not/negation (!)
@@ -90,5 +90,55 @@ const char* get_mnemonic(Opcode oc)
     case OP_XCG: return "OP_XCG";    // exchange/swap
     case OP_XOR: return "OP_XOR";    // bitwise exclusive or (^)
     default:     return "UNDEFINED"; // unsupported opcode
+  }
+}
+
+// Returns true if opcode is a unary operation
+bool is_unary_operation(Opcode oc)
+{
+  switch(oc)
+  {
+    case OP_BNT: // bitwise not/ones' complement (~)
+    case OP_DEC: // decrement (--)
+    case OP_INC: // increment (++)
+    case OP_NEG: // negative (unary -)
+    case OP_NOT: // logical not/negation (!)
+    case OP_POS: // positive
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Returns true if opcode is a binary operation
+bool is_binary_operation(Opcode oc)
+{
+  switch(oc)
+  {
+    case OP_ADD: // add (+)
+    case OP_AND: // logical and (&&)
+    case OP_ASN: // assign (=)
+    case OP_BND: // bitwise and (&)
+    case OP_BOR: // bitwise or (|)
+    case OP_DIV: // divide (/)
+    case OP_EQL: // equal to (==)
+    case OP_GT:  // greater than (>)
+    case OP_GTE: // greater than or equal to (>=)
+    case OP_LT:  // less than (<)
+    case OP_LTE: // less than or equal to (<=)
+    case OP_MOD: // modulo (%)
+    case OP_MUL: // multiply (*)
+    case OP_NEQ: // not equal to (!=)
+    case OP_OR:  // logical or (||)
+    case OP_POW: // power/exponent (**)
+    case OP_SHL: // bitshift left (<<)
+    case OP_SHR: // bitshift right (>>)
+    case OP_SLE: // string length equal to ($=)
+    case OP_SLN: // string length not equal to ($!)
+    case OP_SUB: // subtract (-)
+    case OP_XOR: // bitwise exclusive or (^)
+      return true;
+    default:
+      return false;
   }
 }


### PR DESCRIPTION
## Proposed Change(s)
- Add Docker/Podman build file.
- Update `README.md` to include Docker/Podman build and run steps.
- Fix prompt display when using musl libc by calling `fflush(stdout)`.
- Correct `interpret()` prototype by adding `ConcoctHashMap* map` as a parameter. 
- Fix operand order bug (closes #47).